### PR TITLE
fix: make ask_user compatible with set -u (nounset)

### DIFF
--- a/common-functions.sh
+++ b/common-functions.sh
@@ -288,7 +288,7 @@ function ask_user {
   local input
 
   # Check if the environment variable is already set and validate
-  if [[ -n "${!var_name}" ]]; then
+  if [[ -n "${!var_name:-}" ]]; then
     input="${!var_name}"
     if ! validate_input "$input" "$var_type" "$var_name"; then
         echo "Error: Invalid value for $var_name. Exiting script."


### PR DESCRIPTION
## Summary
- Use `${!var_name:-}` instead of `${!var_name}` to provide an empty default when the variable is unset

## Problem
Scripts using `set -u` (nounset) fail with "unbound variable" error when calling `ask_user` without pre-initializing the variable.

## Solution
The `:-` syntax provides an empty default when the variable is unset, preventing the error while preserving existing behavior:
- Pre-set variables still skip the prompt
- Unset variables now work without initialization

Fixes #9