### PR TITLE
feat: add prompt_required and prompt_secret helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Quick reference of all functions. Click a function name to jump to detailed docu
 | [`assert_hw_rpi`](#assertions-exit-on-failure) | Require Raspberry Pi model | exits |
 | [`is_valid`](#predicates-return-0-or-1) | Validate input value | returns 0/1 |
 | [`get_sudo`](#getters-echo-a-value) | Get sudo prefix if needed | echoes |
-| [`prompt_user`](#prompts-interactive-input) | Interactive user input | sets var |
+| [`prompt_user`](#prompts-interactive-input) | Interactive user input with default | sets var |
+| [`prompt_required`](#prompts-interactive-input) | Required input (no default, must be valid) | sets var |
+| [`prompt_secret`](#prompts-interactive-input) | Hidden input for secrets | sets var |
 | [`apt_update`](#apt-package-management) | Update all packages | — |
 | [`apt_install`](#apt-package-management) | Install packages | returns 0/1 |
 | [`set_colors`](#colors) | Initialize color variables | sets vars |
@@ -96,6 +98,11 @@ ${sudo_cmd:+$sudo_cmd} systemctl restart nginx
 
 ### Prompts (interactive input)
 
+Three variants for different input shapes. All three pre-fill from environment
+variables (skipping the prompt) for non-interactive usage.
+
+#### `prompt_user` — input with default
+
 ```bash
 prompt_user "VAR_NAME" "default" "Prompt message" "type"
 ```
@@ -116,11 +123,52 @@ prompt_user "EMAIL" "admin@example.com" "Contact email" "email"
 prompt_user "SERVER" "localhost" "Server address" "host"
 ```
 
-**Non-interactive mode:** Set environment variables before running the script:
+#### `prompt_required` — required input (no default)
+
+Use when there is no sensible default and an empty value should re-prompt
+instead of being accepted.
+
+```bash
+prompt_required "VAR_NAME" "Prompt message" "type"
+```
+
+**Parameters:**
+- `VAR_NAME` - Variable name to store result (will be created)
+- `Prompt message` - Text shown to user
+- `type` - Validation type (optional, defaults to `str`)
+
+**Examples:**
+
+```bash
+prompt_required "HOSTNAME" "Public hostname" "host"
+prompt_required "ADMIN_EMAIL" "Administrator email" "email"
+```
+
+#### `prompt_secret` — hidden input for secrets
+
+Input is not echoed to the terminal. Always required (non-empty).
+
+```bash
+prompt_secret "VAR_NAME" "Prompt message"
+```
+
+**Parameters:**
+- `VAR_NAME` - Variable name to store result (will be created)
+- `Prompt message` - Text shown to user
+
+**Example:**
+
+```bash
+prompt_secret "DB_PASSWORD" "Database password"
+```
+
+**Non-interactive mode (all three):** Set environment variables before running
+the script:
 
 ```bash
 export USERNAME="deploy"
 export PORT="3000"
+export DB_PASSWORD="…"
 ./script.sh  # Uses env vars, skips prompts
 ```
 

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -283,6 +283,74 @@ function prompt_user() {
     _ref="$input"
 }
 
+# Prompt the user for a required value (no default, must be non-empty and valid).
+# Checks environment variables first for non-interactive usage.
+# Parameters:
+# $1 - The variable name (will be all caps)
+# $2 - The prompt to display to the user
+# $3 - (Optional) The type of the variable (y/n, num, str, email, host). Default is str.
+# Example:
+# prompt_required "MY_HOST" "Please enter a hostname" "host"
+function prompt_required() {
+    local var_name="$1"
+    local prompt="$2"
+    local var_type="${3:-str}"
+
+    local input
+
+    # Check if the environment variable is already set and validate
+    if [[ -n "${!var_name:-}" ]]; then
+        input="${!var_name}"
+        if ! is_valid "$input" "$var_type" "$var_name"; then
+            echo "Error: Invalid value for $var_name. Exiting script."
+            exit 1
+        fi
+    else
+        while true; do
+            read -r -p "${prompt}: " input
+            if is_valid "$input" "$var_type" "$var_name"; then
+                break
+            fi
+        done
+    fi
+
+    # Use nameref instead of eval for safety
+    declare -n _ref="$var_name"
+    _ref="$input"
+}
+
+# Prompt the user for a secret (input is hidden, must be non-empty).
+# Checks environment variables first for non-interactive usage.
+# Parameters:
+# $1 - The variable name (will be all caps)
+# $2 - The prompt to display to the user
+# Example:
+# prompt_secret "MY_PASSWORD" "Please enter your password"
+function prompt_secret() {
+    local var_name="$1"
+    local prompt="$2"
+
+    local input
+
+    # Check if the environment variable is already set
+    if [[ -n "${!var_name:-}" ]]; then
+        input="${!var_name}"
+    else
+        while true; do
+            read -r -s -p "${prompt}: " input
+            echo
+            if [[ -n "$input" ]]; then
+                break
+            fi
+            echo "Invalid value for $var_name. Expected a non-empty string."
+        done
+    fi
+
+    # Use nameref instead of eval for safety
+    declare -n _ref="$var_name"
+    _ref="$input"
+}
+
 # =============================================================================
 # APT PACKAGE MANAGEMENT
 # =============================================================================

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -292,6 +292,14 @@ function prompt_user() {
 # Example:
 # prompt_required "MY_HOST" "Please enter a hostname" "host"
 function prompt_required() {
+    if [[ -z "${1:-}" || -z "${2:-}" ]]; then
+        echo "Error: prompt_required requires a variable name and a prompt." >&2
+        return 1
+    fi
+    if ! [[ "$1" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "Error: '$1' is not a valid Bash variable name." >&2
+        return 1
+    fi
     local var_name="$1"
     local prompt="$2"
     local var_type="${3:-str}"
@@ -307,7 +315,11 @@ function prompt_required() {
         fi
     else
         while true; do
-            read -r -p "${prompt}: " input
+            # Bail on EOF/closed stdin so the loop can't spin in non-interactive runs.
+            if ! read -r -p "${prompt}: " input; then
+                echo "Error: stdin closed before $var_name was provided. Set $var_name in the environment for non-interactive use." >&2
+                return 1
+            fi
             if is_valid "$input" "$var_type" "$var_name"; then
                 break
             fi
@@ -327,6 +339,14 @@ function prompt_required() {
 # Example:
 # prompt_secret "MY_PASSWORD" "Please enter your password"
 function prompt_secret() {
+    if [[ -z "${1:-}" || -z "${2:-}" ]]; then
+        echo "Error: prompt_secret requires a variable name and a prompt." >&2
+        return 1
+    fi
+    if ! [[ "$1" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "Error: '$1' is not a valid Bash variable name." >&2
+        return 1
+    fi
     local var_name="$1"
     local prompt="$2"
 
@@ -335,11 +355,24 @@ function prompt_secret() {
     # Check if the environment variable is already set
     if [[ -n "${!var_name:-}" ]]; then
         input="${!var_name}"
+        # Reject blank/whitespace-only secrets but preserve any value with content
+        # verbatim (passwords may legitimately contain leading/trailing spaces).
+        if [[ -z "${input//[[:space:]]/}" ]]; then
+            echo "Error: $var_name is set but blank. Provide a non-empty value." >&2
+            return 1
+        fi
     else
         while true; do
-            read -r -s -p "${prompt}: " input
+            # IFS= prevents read from stripping leading/trailing whitespace from
+            # the secret. Bail on EOF so the loop can't spin in non-interactive runs.
+            if ! IFS= read -r -s -p "${prompt}: " input; then
+                # Newline only when a TTY actually saw the hanging prompt.
+                [[ -t 0 ]] && printf '\n' >&2
+                echo "Error: stdin closed before $var_name was provided. Set $var_name in the environment for non-interactive use." >&2
+                return 1
+            fi
             echo
-            if [[ -n "$input" ]]; then
+            if [[ -n "${input//[[:space:]]/}" ]]; then
                 break
             fi
             echo "Invalid value for $var_name. Expected a non-empty string."


### PR DESCRIPTION
## Summary

`prompt_user` covers the with-default case well, but two common shapes have no library helper today and get reimplemented downstream (e.g. in [oszuidwest/zw-transfer](https://github.com/oszuidwest/zw-transfer) `install.sh`):

- **Required field, no default.** Workaround today: `prompt_user "VAR" "" "..." "str"`, which renders an awkward `[default: ]:` suffix and relies on `is_valid str` failing on empty input.
- **Secret field, hidden input.** No equivalent at all — consumers reach for raw `read -r -s` and reimplement the env-pre-fill / non-empty / re-prompt loop.

This PR adds both as first-class helpers that follow the existing `prompt_user` contract:

- env pre-fill for non-interactive usage (`${!var_name:-}` lookup)
- validation via `is_valid` (full type set for `prompt_required`; non-empty check for `prompt_secret`)
- re-prompt loop on bad input
- nameref assignment instead of `eval`

```bash
prompt_required "HOSTNAME" "Public hostname" "host"
prompt_secret   "DB_PASSWORD" "Database password"
```

`prompt_secret` deliberately does not take a `type` argument — secrets vary too widely (API keys, passwords, tokens) for a single validation type to generalise; non-empty is the only meaningful baseline.

## Test plan

- [x] `shellcheck common-functions.sh` — clean.
- [x] Smoke check (locally on macOS bash 3.2 fails on the existing `declare -n` in `prompt_user` too — the library targets bash 4+ which is the standard on every Debian/Ubuntu/Alpine target).
- [x] CI lint workflow on this PR.

## Downstream

`oszuidwest/zw-transfer/install.sh` will drop ~44 lines of duplicated helper code once this lands and `main` pulls the new helpers.