### PR TITLE
Add system hardening baseline helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Quick reference of all functions. Click a function name to jump to detailed docu
 | [`apt_install`](#apt-package-management) | Install packages | returns 0/1 |
 | [`set_colors`](#colors) | Initialize color variables | sets vars |
 | [`set_timezone`](#setters) | Set system timezone | returns 0/1 |
+| [`set_system_hardening_baseline`](#setters) | Apply host hardening baseline | best-effort |
 | [`file_backup`](#file-operations) | Create timestamped backup | returns 0/1/2 |
 | [`file_download`](#file-operations) | Download file(s) with retry | returns 0/1 |
 
@@ -186,7 +187,20 @@ apt_install --silent nginx         # Same, but suppress output
 
 ```bash
 set_timezone "Europe/Amsterdam"    # Returns 1 if timezone invalid
+set_system_hardening_baseline --silent
 ```
+
+`set_system_hardening_baseline` applies a best-effort Debian/Ubuntu/Raspberry
+Pi host baseline:
+
+- Installs `nvme-cli` and `smartmontools` when `apt` is available
+- Enables `smartmontools.service` or `smartd.service` when systemd is available
+- Writes `/etc/systemd/journald.conf.d/99-size-limit.conf` with
+  `SystemMaxUse=512M`, restarts journald, and vacuums existing logs
+
+The function is idempotent and intentionally non-fatal on systems without apt,
+systemd, journalctl, or NVMe hardware. Use `--journald-max-use=1G` to override
+the default journald limit.
 
 ### File Operations
 
@@ -230,7 +244,8 @@ echo -e "${UNDERLINE}Underlined${NC}"
 
 | Flag | Available in | Description |
 |------|--------------|-------------|
-| `--silent` | `apt_update`, `apt_install` | Suppress output, auto-accept prompts |
+| `--silent` | `apt_update`, `apt_install`, `set_system_hardening_baseline` | Suppress output, auto-accept prompts |
+| `--journald-max-use=SIZE` | `set_system_hardening_baseline` | Override journald limit |
 | `--backup` | `file_download` | Backup existing file before overwriting |
 
 Flags can appear anywhere in the argument list:

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -524,6 +524,144 @@ function set_timezone() {
     fi
 }
 
+# Apply baseline Linux host hardening.
+#
+# This is intentionally best-effort: it should improve Debian/Ubuntu/Raspberry
+# Pi hosts when the required platform tools are available, but it must not break
+# installers on systems without apt, systemd, journald, or NVMe hardware.
+#
+# Actions:
+# - Install nvme-cli and smartmontools when apt is available
+# - Enable smart disk monitoring when systemd exposes a smartd service
+# - Limit persistent journald storage and vacuum existing logs
+#
+# Parameters:
+# --silent - (Optional) Suppress apt output
+# --journald-max-use=SIZE - (Optional) Default: 512M
+function set_system_hardening_baseline() {
+    local silent=false
+    local journald_max_use="512M"
+    local arg
+
+    for arg in "$@"; do
+        case "$arg" in
+            --silent)
+                silent=true
+                ;;
+            --journald-max-use=*)
+                journald_max_use="${arg#*=}"
+                ;;
+        esac
+    done
+
+    echo -e "${BLUE}►► Applying system hardening baseline...${NC}"
+
+    local sudo_cmd
+    sudo_cmd=$(get_sudo)
+    if [[ -n "$sudo_cmd" ]] && ! command -v "$sudo_cmd" > /dev/null 2>&1; then
+        echo -e "${YELLOW}Skipping system hardening: sudo is not available.${NC}"
+        return 0
+    fi
+
+    _install_disk_health_tools "$silent" || true
+    _enable_smart_monitoring || true
+    _limit_journald_storage "$journald_max_use" || true
+}
+
+function _install_disk_health_tools() {
+    local silent="$1"
+    local package
+
+    if ! command -v apt > /dev/null 2>&1; then
+        echo -e "${YELLOW}Skipping disk health tools: apt is not available.${NC}"
+        return 0
+    fi
+
+    for package in nvme-cli smartmontools; do
+        if command -v dpkg > /dev/null 2>&1 && dpkg -s "$package" > /dev/null 2>&1; then
+            echo -e "${GREEN}✓ ${package} is already installed${NC}"
+            continue
+        fi
+
+        if [[ "$silent" == true ]]; then
+            if ! apt_install --silent "$package"; then
+                echo -e "${YELLOW}Warning: failed to install ${package}; continuing.${NC}"
+            fi
+        elif ! apt_install "$package"; then
+            echo -e "${YELLOW}Warning: failed to install ${package}; continuing.${NC}"
+        fi
+    done
+}
+
+function _has_systemd() {
+    command -v systemctl > /dev/null 2>&1 && [[ -d /run/systemd/system ]]
+}
+
+function _enable_smart_monitoring() {
+    if ! _has_systemd; then
+        echo -e "${YELLOW}Skipping smartd activation: systemd is not available.${NC}"
+        return 0
+    fi
+
+    local sudo_cmd service
+    sudo_cmd=$(get_sudo)
+
+    for service in smartmontools.service smartd.service; do
+        if systemctl list-unit-files "$service" 2>/dev/null | awk '{print $1}' | grep -qx "$service"; then
+            echo -e "${BLUE}►► Enabling ${service}...${NC}"
+            if ${sudo_cmd:+$sudo_cmd} systemctl enable --now "$service" > /dev/null 2>&1; then
+                echo -e "${GREEN}✓ ${service} is enabled${NC}"
+            else
+                echo -e "${YELLOW}Warning: failed to enable ${service}; continuing.${NC}"
+            fi
+            return 0
+        fi
+    done
+
+    echo -e "${YELLOW}Skipping smartd activation: no smartmontools systemd service found.${NC}"
+}
+
+function _limit_journald_storage() {
+    local max_use="$1"
+
+    if ! _has_systemd || ! command -v journalctl > /dev/null 2>&1; then
+        echo -e "${YELLOW}Skipping journald limit: systemd/journalctl is not available.${NC}"
+        return 0
+    fi
+
+    local sudo_cmd conf_dir conf_file temp_file
+    sudo_cmd=$(get_sudo)
+    conf_dir="/etc/systemd/journald.conf.d"
+    conf_file="${conf_dir}/99-size-limit.conf"
+    temp_file=$(mktemp)
+
+    printf '[Journal]\nSystemMaxUse=%s\n' "$max_use" > "$temp_file"
+
+    echo -e "${BLUE}►► Limiting journald storage to ${max_use}...${NC}"
+    if ! ${sudo_cmd:+$sudo_cmd} mkdir -p "$conf_dir"; then
+        echo -e "${YELLOW}Warning: failed to create ${conf_dir}; continuing.${NC}"
+        rm -f "$temp_file"
+        return 0
+    fi
+
+    if ! ${sudo_cmd:+$sudo_cmd} install -m 0644 "$temp_file" "$conf_file"; then
+        echo -e "${YELLOW}Warning: failed to write ${conf_file}; continuing.${NC}"
+        rm -f "$temp_file"
+        return 0
+    fi
+    rm -f "$temp_file"
+
+    if ! ${sudo_cmd:+$sudo_cmd} systemctl restart systemd-journald.service > /dev/null 2>&1; then
+        echo -e "${YELLOW}Warning: failed to restart systemd-journald; continuing.${NC}"
+    fi
+
+    if ${sudo_cmd:+$sudo_cmd} journalctl --vacuum-size="$max_use" > /dev/null 2>&1; then
+        echo -e "${GREEN}✓ journald storage limit applied${NC}"
+    else
+        echo -e "${YELLOW}Warning: failed to vacuum journald logs; continuing.${NC}"
+    fi
+}
+
 # =============================================================================
 # FILE OPERATIONS
 # =============================================================================


### PR DESCRIPTION
## Summary
- add `set_system_hardening_baseline` for Debian/Ubuntu/Raspberry Pi host installers
- install `nvme-cli` and `smartmontools` best-effort when apt is available
- enable `smartmontools.service`/`smartd.service` when systemd is available
- set journald `SystemMaxUse=512M` and vacuum existing logs when journald is available

## Tests
- `bash -n common-functions.sh`
- `shellcheck common-functions.sh`
- `bash -c 'source ./common-functions.sh; set_system_hardening_baseline --silent'` on a non-apt/non-systemd workstation to verify graceful skips