### PR TITLE
Add time sync and journald setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Quick reference of all functions. Click a function name to jump to detailed docu
 | [`apt_install`](#apt-package-management) | Install packages | returns 0/1 |
 | [`set_colors`](#colors) | Initialize color variables | sets vars |
 | [`set_timezone`](#setters) | Set system timezone | returns 0/1 |
+| [`set_time_sync`](#setters) | Enable system time synchronization | returns 0/1 |
+| [`set_journald_limits`](#setters) | Limit journald storage | returns 0/1 |
 | [`file_backup`](#file-operations) | Create timestamped backup | returns 0/1/2 |
 | [`file_download`](#file-operations) | Download file(s) with retry | returns 0/1 |
 
@@ -186,7 +188,21 @@ apt_install --silent nginx         # Same, but suppress output
 
 ```bash
 set_timezone "Europe/Amsterdam"    # Returns 1 if timezone invalid
+set_time_sync                       # Enable NTP when systemd/timedatectl exist
+set_journald_limits                 # SystemMaxUse=512M, RuntimeMaxUse=128M
+set_journald_limits 1G 256M         # Custom SystemMaxUse and RuntimeMaxUse
+set_journald_limits 512M 128M --vacuum
 ```
+
+`set_time_sync` enables system time synchronization through `timedatectl` when
+the host is running systemd. It is safe to call from installers that also run on
+non-systemd hosts: unsupported systems are skipped without error.
+
+`set_journald_limits` writes a managed drop-in at
+`/etc/systemd/journald.conf.d/90-bash-functions-size-limit.conf`, restarts
+`systemd-journald`, and optionally vacuums archived logs when `--vacuum` is
+provided. Size values must be positive numbers with an optional `K`, `M`, `G`,
+`T`, `P`, or `E` suffix.
 
 ### File Operations
 
@@ -231,6 +247,7 @@ echo -e "${UNDERLINE}Underlined${NC}"
 | Flag | Available in | Description |
 |------|--------------|-------------|
 | `--silent` | `apt_update`, `apt_install` | Suppress output, auto-accept prompts |
+| `--vacuum` | `set_journald_limits` | Vacuum archived journald logs after applying limits |
 | `--backup` | `file_download` | Backup existing file before overwriting |
 
 Flags can appear anywhere in the argument list:
@@ -273,6 +290,20 @@ apt_install nginx php --silent    # Flag last
 |------|---------|
 | 0 | Timezone set successfully |
 | 1 | Invalid timezone |
+
+**`set_time_sync`:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | Time synchronization enabled, already enabled, or unsupported host skipped |
+| 1 | Host supports time sync configuration, but enabling it failed |
+
+**`set_journald_limits`:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | Journald limits applied, or unsupported host skipped |
+| 1 | Invalid size value or failed systemd/journald configuration |
 
 ### Handling Errors
 

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -43,6 +43,17 @@ function _strip_flag() {
     done
 }
 
+# Predicate: check if the host is booted with systemd as service manager.
+function _has_systemd() {
+    command -v systemctl > /dev/null 2>&1 && [[ -d /run/systemd/system ]]
+}
+
+# Predicate: validate a systemd size value (bytes or K/M/G/T/P/E suffix).
+function _is_valid_systemd_size() {
+    local size="$1"
+    [[ "$size" =~ ^[1-9][0-9]*([KMGTPE])?$ ]]
+}
+
 # =============================================================================
 # INITIALIZATION
 # =============================================================================
@@ -522,6 +533,155 @@ function set_timezone() {
         echo -e "${RED}Error: Invalid timezone: ${timezone}${NC}"
         return 1
     fi
+}
+
+# Enable system time synchronization when systemd/timedatectl are available.
+# Returns 0 when enabled, already enabled, or safely skipped on unsupported hosts.
+# Returns 1 when a supported host cannot be changed.
+function set_time_sync() {
+    if [[ $# -ne 0 ]]; then
+        echo -e "${RED}Error: set_time_sync does not accept arguments.${NC}"
+        return 1
+    fi
+
+    if ! _has_systemd || ! command -v timedatectl > /dev/null 2>&1; then
+        echo -e "${YELLOW}Skipping time synchronization: systemd/timedatectl is not available.${NC}"
+        return 0
+    fi
+
+    local ntp_state
+    ntp_state=$(timedatectl show -p NTP 2>/dev/null || true)
+    if [[ "$ntp_state" == "NTP=yes" ]]; then
+        echo -e "${GREEN}Time synchronization is already enabled.${NC}"
+        return 0
+    fi
+
+    local sudo_cmd
+    sudo_cmd=$(get_sudo)
+    if [[ -n "$sudo_cmd" ]] && ! command -v "$sudo_cmd" > /dev/null 2>&1; then
+        echo -e "${RED}Error: sudo is required to enable time synchronization but is not available.${NC}"
+        return 1
+    fi
+
+    echo -e "${BLUE}►► Enabling system time synchronization...${NC}"
+    if ${sudo_cmd:+$sudo_cmd} timedatectl set-ntp true > /dev/null 2>&1; then
+        echo -e "${GREEN}Time synchronization enabled.${NC}"
+        return 0
+    fi
+
+    echo -e "${RED}Error: failed to enable time synchronization.${NC}"
+    return 1
+}
+
+# Limit systemd-journald storage usage.
+# Parameters:
+# $1 - (Optional) SystemMaxUse value. Default: 512M
+# $2 - (Optional) RuntimeMaxUse value. Default: 128M
+# --vacuum - (Optional) Vacuum archived logs after applying the limit
+function set_journald_limits() {
+    local system_max_use="512M"
+    local runtime_max_use="128M"
+    local vacuum=false
+    local values=()
+    local arg
+
+    for arg in "$@"; do
+        case "$arg" in
+            --vacuum)
+                vacuum=true
+                ;;
+            --*)
+                echo -e "${RED}Error: unknown option for set_journald_limits.${NC}"
+                return 1
+                ;;
+            *)
+                values+=("$arg")
+                ;;
+        esac
+    done
+
+    if [[ ${#values[@]} -gt 2 ]]; then
+        echo -e "${RED}Error: set_journald_limits accepts at most two size values.${NC}"
+        return 1
+    fi
+
+    if [[ ${#values[@]} -ge 1 ]]; then
+        system_max_use="${values[0]}"
+    fi
+    if [[ ${#values[@]} -ge 2 ]]; then
+        runtime_max_use="${values[1]}"
+    fi
+
+    if ! _is_valid_systemd_size "$system_max_use"; then
+        echo -e "${RED}Error: invalid SystemMaxUse value.${NC}"
+        return 1
+    fi
+    if ! _is_valid_systemd_size "$runtime_max_use"; then
+        echo -e "${RED}Error: invalid RuntimeMaxUse value.${NC}"
+        return 1
+    fi
+
+    if ! _has_systemd || ! command -v journalctl > /dev/null 2>&1; then
+        echo -e "${YELLOW}Skipping journald limits: systemd/journalctl is not available.${NC}"
+        return 0
+    fi
+
+    local sudo_cmd
+    sudo_cmd=$(get_sudo)
+    if [[ -n "$sudo_cmd" ]] && ! command -v "$sudo_cmd" > /dev/null 2>&1; then
+        echo -e "${RED}Error: sudo is required to configure journald but is not available.${NC}"
+        return 1
+    fi
+
+    local conf_dir conf_file temp_file
+    conf_dir="/etc/systemd/journald.conf.d"
+    conf_file="${conf_dir}/90-bash-functions-size-limit.conf"
+
+    if ! temp_file=$(mktemp); then
+        echo -e "${RED}Error: failed to create temporary journald config.${NC}"
+        return 1
+    fi
+
+    {
+        printf '# Managed by bash-functions set_journald_limits\n'
+        printf '[Journal]\n'
+        printf 'SystemMaxUse=%s\n' "$system_max_use"
+        printf 'RuntimeMaxUse=%s\n' "$runtime_max_use"
+    } > "$temp_file"
+
+    echo -e "${BLUE}►► Setting journald limits: SystemMaxUse=${system_max_use}, RuntimeMaxUse=${runtime_max_use}...${NC}"
+    if ! ${sudo_cmd:+$sudo_cmd} mkdir -p "$conf_dir"; then
+        echo -e "${RED}Error: failed to create ${conf_dir}.${NC}"
+        rm -f "$temp_file"
+        return 1
+    fi
+
+    if ! ${sudo_cmd:+$sudo_cmd} install -m 0644 "$temp_file" "$conf_file"; then
+        echo -e "${RED}Error: failed to write ${conf_file}.${NC}"
+        rm -f "$temp_file"
+        return 1
+    fi
+    rm -f "$temp_file"
+
+    if ! ${sudo_cmd:+$sudo_cmd} systemctl restart systemd-journald.service > /dev/null 2>&1; then
+        echo -e "${RED}Error: failed to restart systemd-journald.${NC}"
+        return 1
+    fi
+
+    if [[ "$vacuum" == true ]]; then
+        local vacuum_size
+        vacuum_size="$system_max_use"
+        if [[ ! -d /var/log/journal ]]; then
+            vacuum_size="$runtime_max_use"
+        fi
+
+        if ! ${sudo_cmd:+$sudo_cmd} journalctl --vacuum-size="$vacuum_size" > /dev/null 2>&1; then
+            echo -e "${RED}Error: failed to vacuum journald logs.${NC}"
+            return 1
+        fi
+    fi
+
+    echo -e "${GREEN}Journald limits applied.${NC}"
 }
 
 # =============================================================================

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -550,6 +550,9 @@ function set_time_sync() {
     fi
 
     local ntp_state
+    # Bare assignment propagates the substitution's exit status, so `|| true` is
+    # load-bearing: it keeps `set -e` callers alive when timedatectl errors
+    # (e.g. degraded systemd / no timedated). Do not remove.
     ntp_state=$(timedatectl show -p NTP 2>/dev/null || true)
     if [[ "$ntp_state" == "NTP=yes" ]]; then
         echo -e "${GREEN}Time synchronization is already enabled.${NC}"
@@ -558,13 +561,9 @@ function set_time_sync() {
 
     local sudo_cmd
     sudo_cmd=$(get_sudo)
-    if [[ -n "$sudo_cmd" ]] && ! command -v "$sudo_cmd" > /dev/null 2>&1; then
-        echo -e "${RED}Error: sudo is required to enable time synchronization but is not available.${NC}"
-        return 1
-    fi
 
     echo -e "${BLUE}►► Enabling system time synchronization...${NC}"
-    if ${sudo_cmd:+$sudo_cmd} timedatectl set-ntp true > /dev/null 2>&1; then
+    if ${sudo_cmd:+$sudo_cmd} timedatectl set-ntp true > /dev/null; then
         echo -e "${GREEN}Time synchronization enabled.${NC}"
         return 0
     fi
@@ -628,10 +627,6 @@ function set_journald_limits() {
 
     local sudo_cmd
     sudo_cmd=$(get_sudo)
-    if [[ -n "$sudo_cmd" ]] && ! command -v "$sudo_cmd" > /dev/null 2>&1; then
-        echo -e "${RED}Error: sudo is required to configure journald but is not available.${NC}"
-        return 1
-    fi
 
     local conf_dir conf_file temp_file
     conf_dir="/etc/systemd/journald.conf.d"
@@ -663,25 +658,23 @@ function set_journald_limits() {
     fi
     rm -f "$temp_file"
 
-    if ! ${sudo_cmd:+$sudo_cmd} systemctl restart systemd-journald.service > /dev/null 2>&1; then
-        echo -e "${RED}Error: failed to restart systemd-journald.${NC}"
+    if ! ${sudo_cmd:+$sudo_cmd} systemctl restart systemd-journald.service > /dev/null; then
+        echo -e "${RED}Error: failed to restart systemd-journald. ${conf_file} was written and will apply once systemd-journald restarts successfully.${NC}"
         return 1
     fi
 
     if [[ "$vacuum" == true ]]; then
-        local vacuum_size
-        vacuum_size="$system_max_use"
-        if [[ ! -d /var/log/journal ]]; then
-            vacuum_size="$runtime_max_use"
-        fi
+        local vacuum_size="$system_max_use"
+        [[ -d /var/log/journal ]] || vacuum_size="$runtime_max_use"
 
-        if ! ${sudo_cmd:+$sudo_cmd} journalctl --vacuum-size="$vacuum_size" > /dev/null 2>&1; then
+        if ! ${sudo_cmd:+$sudo_cmd} journalctl --vacuum-size="$vacuum_size" > /dev/null; then
             echo -e "${RED}Error: failed to vacuum journald logs.${NC}"
             return 1
         fi
     fi
 
     echo -e "${GREEN}Journald limits applied.${NC}"
+    return 0
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- add set_time_sync for systemd/timedatectl-based NTP enablement
- add set_journald_limits with validated SystemMaxUse/RuntimeMaxUse values and optional vacuuming
- document usage, flags, and return codes in README
- refine failure handling so real action stderr remains visible while set -e callers survive timedatectl probe failures

## Validation
- bash -n common-functions.sh
- shellcheck common-functions.sh
- git diff --check
- local set -euo pipefail smoke test for unsupported host skip paths
- Docker stub regression suite on debian:bookworm covering set -e behavior, argument guard, visible action stderr, journald rendering, restart failures, invalid sizes, and metacharacter rejection
- Docker smoke tests on debian:bookworm, debian:trixie-slim, ubuntu:24.04, fedora:latest, and alpine:3.20 with Bash
- Docker debian:bookworm with systemd tools installed but not booted as systemd to verify safe skip behavior
- privileged booted-systemd debian:bookworm container testing real set_time_sync, set_journald_limits, and set_journald_limits --vacuum