### PR TITLE
feat!: make file_backup absent-safe (drop return 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Quick reference of all functions. Click a function name to jump to detailed docu
 | [`set_timezone`](#setters) | Set system timezone | returns 0/1 |
 | [`set_time_sync`](#setters) | Enable system time synchronization | returns 0/1 |
 | [`set_journald_limits`](#setters) | Limit journald storage | returns 0/1 |
-| [`file_backup`](#file-operations) | Create timestamped backup | returns 0/1/2 |
+| [`file_backup`](#file-operations) | Create timestamped backup | returns 0/1 |
 | [`file_download`](#file-operations) | Download file(s) with retry | returns 0/1 |
 
 ## Function Reference
@@ -266,9 +266,15 @@ apt_install nginx php --silent    # Flag last
 
 | Code | Meaning |
 |------|---------|
-| 0 | Backup created successfully |
+| 0 | Backup created, or nothing to back up (file absent) |
 | 1 | Backup failed |
-| 2 | File does not exist (nothing to backup) |
+
+An absent file is treated as success (a no-op), so the backup-before-overwrite
+idiom stays `set -e`-safe without an `[ -f "$file" ]` guard:
+
+```bash
+file_backup "$config" || exit 1   # absent = nothing to do, real failure = exit
+```
 
 **`file_download`:**
 
@@ -314,13 +320,8 @@ if ! file_download "$url" "$dest" "config"; then
     cp /defaults/config.txt "$dest"
 fi
 
-# Handle backup status
-file_backup "/etc/app.conf"
-case $? in
-    0) echo "Backup created" ;;
-    1) echo "Backup failed!" ; exit 1 ;;
-    2) echo "No existing file, skipping backup" ;;
-esac
+# Back up an existing config before overwriting it (absent file = no-op)
+file_backup "/etc/app.conf" || exit 1
 
 # Validate before using
 if ! is_valid "$input" "email" "EMAIL"; then
@@ -414,6 +415,18 @@ is_valid "$input" "num" "PORT"  # Exits if invalid!
 | `download_file` | `file_download` |
 | `download_file ... backup` | `file_download ... --backup` |
 | Multi-file `URL:filename` | Multi-file `URL\|filename` |
+
+### Behavioral changes
+
+**`file_backup` return codes:** `file_backup` no longer returns `2` for an
+absent file — it now returns `0` (absent = nothing to back up = success).
+Callers that branched on `2` (`case $?` / `[ $? -eq 2 ]`) should drop that
+branch; absent and backed-up are both `0` now. This makes the common
+backup-before-overwrite call correct under `set -e`:
+
+```bash
+file_backup "$config" || exit 1   # was unsafe: an absent file returned 2
+```
 
 ## License
 

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -685,14 +685,16 @@ function set_journald_limits() {
 # Parameters:
 # $1 - The path to the file to backup
 # Returns:
-# 0 - Backup created successfully
+# 0 - Backup created, or nothing to back up (file absent)
 # 1 - Backup failed
-# 2 - File does not exist (no backup needed)
 function file_backup() {
     local file="$1"
 
+    # Nothing to back up is success, not an error: this keeps the common
+    # "back up before overwrite" call set -e-safe (file_backup "$f" || exit 1)
+    # without forcing every caller to add an [ -f "$f" ] guard.
     if [[ ! -f "$file" ]]; then
-        return 2
+        return 0
     fi
 
     local backup_path
@@ -769,9 +771,11 @@ function file_download() {
             local url="${url_file%|*}"
             local file_dest="${dest_dir}/${filename}"
 
-            # Backup if requested
-            if [[ "$backup_option" == true ]]; then
-                file_backup "${file_dest}" || true
+            # Backup if requested; a real backup failure must not be masked,
+            # so skip the download rather than overwrite an un-backed-up file
+            if [[ "$backup_option" == true ]] && ! file_backup "${file_dest}"; then
+                failed=1
+                continue
             fi
 
             if [[ -z "$sudo_cmd" ]]; then
@@ -804,9 +808,10 @@ function file_download() {
             backup_option=true
         fi
 
-        # Backup if requested
-        if [[ "$backup_option" == true ]]; then
-            file_backup "${dest}" || true
+        # Backup if requested; abort on a real backup failure rather than
+        # overwrite an un-backed-up file
+        if [[ "$backup_option" == true ]] && ! file_backup "${dest}"; then
+            return 1
         fi
 
         local sudo_cmd


### PR DESCRIPTION
## What & why

This takes **option A** for the problem raised in #16: instead of adding a separate `file_backup_if_exists` wrapper alongside the tri-state `file_backup`, it folds the existence check into `file_backup` itself and drops the awkward `return 2`.

`file_backup` now has clean two-state semantics:

| Code | Meaning |
|------|---------|
| 0 | Backup created, **or nothing to back up (file absent)** |
| 1 | Backup failed |

### The case for changing the default rather than wrapping it

The tri-state's one benefit — distinguishing "absent" from "success" — is used by **zero** real callers:

- This library's own `file_download --backup` threw the distinction away with `file_backup ... || true`.
- Every downstream installer wraps it in `[ -f "$f" ] && file_backup`, re-deriving the very check `file_backup` already did and discarded as `2`.

Worse, the tri-state forced a latent bug into `file_download`: under `set -e`, an absent file (return `2`, the normal case on a fresh install) would abort the script, so the call was neutralised with `|| true` — which **also silently swallowed real backup failures (`1`)**, overwriting the file with no safety net. Two-state semantics dissolves that dilemma.

## Changes

- **`common-functions.sh`**
  - `file_backup`: absent file now returns `0` (silent no-op) instead of `2`. The `cp`/backup path is unchanged.
  - `file_download --backup`: stops masking real backup failures. Single-file mode aborts (`return 1`); multi-file mode flags `failed=1` and skips that file's download rather than overwrite an un-backed-up file. An absent file remains a clean no-op.
- **`README.md`**: return-code table, function overview row, the error-handling example (now the `set -e`-safe `file_backup "$f" || exit 1` idiom), and a behavioral-changes note.

## Breaking change

`file_backup` no longer returns `2` for an absent file — it returns `0`. Callers that branched on `2` (`case $?` / `[ $? -eq 2 ]`) should drop that branch. The downstream installers currently guard with `[ -f ]`, which stays correct (now redundant); none branch on `2`.

## Verification

- `bash -n common-functions.sh` — clean
- `shellcheck common-functions.sh` — clean (the only CI gate)
- Manual smoke test: absent file → `rc 0` and `file_backup "$f" || exit 1` is `set -e`-safe; existing file → `rc 0` and timestamped `.bak` created.

Closes #16.